### PR TITLE
recycle rep to pass data.table 1.12.2

### DIFF
--- a/tests/testthat/test-link_ethocope_metadata.R
+++ b/tests/testthat/test-link_ethocope_metadata.R
@@ -55,7 +55,7 @@ test_that("link_ethoscope_metadata with date, machine name, and ROIs", {
 
   query <- data.table::as.data.table(query)
   query <- query[,.(region_id=1:5),by=c(colnames(query))]
-  query[, treatment := 1:3]
+  query[, treatment := rep(1:3,length.out=.N)]
 
   out <-  link_ethoscope_metadata(query, dir)
   expect_equal(nrow(out), 3*5)

--- a/tests/testthat/test-link_ethoscope_metadata_remote.R
+++ b/tests/testthat/test-link_ethoscope_metadata_remote.R
@@ -45,7 +45,7 @@ test_that("parse_query with date, machine name, and ROIs", {
 
   query <- data.table::as.data.table(query)
   query <- query[,.(region_id=1:5),by=c(colnames(query))]
-  query[, treatment := 1:3]
+  query[, treatment := rep(1:3, length.out=.N)]
 
   result_dir <- tempdir()
   out1 <- scopr:::link_ethoscope_metadata_remote(query,


### PR DESCRIPTION
Hi Quentin,
Thanks for your reply to my email last month.
https://github.com/Rdatatable/data.table/pull/3310
https://github.com/Rdatatable/data.table/issues/3347
I've checked that with this PR, `scopr` will pass the next release of data.table.
Could you update on CRAN please?
Best, Matt